### PR TITLE
Changing the site URL to not include /accessibility worked for me

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ github_info:
   organization: civicactions
   repository: accessibility
 
-url: "https://civicactions.github.io/accessibility/" # the base hostname & protocol for your site
+url: "https://civicactions.github.io/accessibility" # the base hostname & protocol for your site
 plugins:
   - jekyll-sitemap
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ github_info:
   organization: civicactions
   repository: accessibility
 
-url: "https://civicactions.github.io/accessibility" # the base hostname & protocol for your site
+url: "https://civicactions.github.io" # the base hostname & protocol for your site
 plugins:
   - jekyll-sitemap
 


### PR DESCRIPTION
Following #65 I tested setting the URL to 'https://civicactions.github.io' seemed to work for my version of the site. Link: https://dmundra.github.io/accessibility/sitemap.xml and seemed to not have any regressions. What do you think @lukefretwell?