### PR TITLE
Fixing empty link error in accessibility site and adding gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.*.swp
+.DS_Store
+.bundle/
+.jekyll*
+.sass-cache/
+_site/
+node_modules
+output.log
+site

--- a/_data/header.yml
+++ b/_data/header.yml
@@ -30,5 +30,5 @@ primary:
   links: primary
 
 # this is a key into _data/navigation.yml
-secondary:
-  links: secondary
+#secondary:
+#  links: secondary


### PR DESCRIPTION
In my testing of accessibility automation tools, I noticed that the site has an empty link in the secondary navigation region. The screenshot is from Wave:

![Screenshot from Wave tool](https://user-images.githubusercontent.com/7096681/107574829-f89fde00-6ba3-11eb-981b-654ae6517dfa.png)

Also including a .gitignore file that I copied from the CA handbook. We could later remove the _site and .jekyll-cache directories.