### PR TITLE
Fix empty links guide playbook

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -1,5 +1,6 @@
 {
   "defaults": {
+    "timeout": 50000,
     "standard": "WCAG2AA"
   }
 }

--- a/_includes/guide.html
+++ b/_includes/guide.html
@@ -4,7 +4,7 @@
         <div class="usa-card__container">
             <div class="usa-card__media">
                 <div class="usa-card__img text-center card-guide">
-                    <a href="{{ site.baseurl }}/guide{{ item.url }}">{{ item.icon }}</a>
+                    <a href="{{ site.baseurl }}/guide{{ item.url }}" aria-label="{{ item.title }}">{{ item.icon }}</a>
                 </div>
             </div>
             <header class="usa-card__header">

--- a/_includes/playbook.html
+++ b/_includes/playbook.html
@@ -4,7 +4,7 @@
         <div class="usa-card__container">
             <div class="usa-card__media">
                 <div class="usa-card__img text-center card-guide">
-                    <a href="{{ site.baseurl }}/playbook{{ item.url }}">{{ item.icon }}</a>
+                    <a href="{{ site.baseurl }}/playbook{{ item.url }}" aria-label="{{ item.title }}">{{ item.icon }}</a>
                 </div>
             </div>
             <header class="usa-card__header">


### PR DESCRIPTION
@lukefretwell this will fix the empty links error we are seeing with fontawesome icons.

Related to #106 