### PR TITLE
Excluding pa11y_output.json file from Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,3 +109,6 @@ defaults:
       type: "people"
     values:
       layout: "people"
+
+exclude:
+  - pa11y_output.json


### PR DESCRIPTION
Tested a tweak to Jekyll to improve pa11y-ci test runner. Creating PR and merging it right after the actions pass.