### PR TITLE
Added hard failure to pa11y-ci pipeline

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -37,3 +37,10 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: '```${{ steps.pa11y_output.outputs.content }}```'
+          
+      - name: Check for pa11y failures.
+        if: contains(steps.pa11y_output.outputs.content, 'errno 2')
+        run: |
+          echo "::error::The site is failing accessibility tests. Please review the comment in the pull request or the pa11y-ci step in the workflow for details."
+          exit 1
+


### PR DESCRIPTION
This change will make the pa11y-ci pipeline have a hard failure when there are accessibility errors.