### PR TITLE
Wrapping pa11y output in <details>

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -36,7 +36,10 @@ jobs:
         uses: thollander/actions-comment-pull-request@master
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          message: '```${{ steps.pa11y_output.outputs.content }}```'
+          message: '<details><summary>Pa11y testing results</summary>
+
+
+```${{ steps.pa11y_output.outputs.content }}```</details>'
           
       - name: Check for pa11y failures.
         if: contains(steps.pa11y_output.outputs.content, 'errno 2')


### PR DESCRIPTION
This change will wrap the comment from pa11y testing in a collapsed ``<details>`` tag.

Results: https://github.com/CivicActions/accessibility/pull/130#issuecomment-791553172