### PR TITLE
Fix playbook and guide sidebar

### DIFF
--- a/_layouts/guide.html
+++ b/_layouts/guide.html
@@ -3,36 +3,38 @@ layout: default
 main:
 class:
 ---
-<div class="guide-container">
-    <div class="handbook-breadcrumb">
-        <div class="">
-            <nav class="usa-breadcrumb" aria-label="Breadcrumbs">
-                <ol class="usa-breadcrumb__list">
-                    <li class="usa-breadcrumb__list-item">
-                        <a href="{{ site.baseurl }}/guide" class="usa-breadcrumb__link">
-                            <span class="guide-title">CivicActions Accessibility Guide</span>
-                        </a>
-                    </li>
-                    <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-                        <span>{{ page.title }}</span>
-                    </li>
-                </ol>
-            </nav>
-        </div>
+<div class="main-breadcrumb">
+    <div class="grid-container">
+        <nav class="usa-breadcrumb" aria-label="Breadcrumbs">
+            <ol class="usa-breadcrumb__list">
+                <li class="usa-breadcrumb__list-item">
+                    <a href="{{ site.baseurl }}/guide" class="usa-breadcrumb__link">
+                        <span class="guide-title">CivicActions Accessibility Guide</span>
+                    </a>
+                </li>
+                <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+                    <span>{{ page.title }}</span>
+                </li>
+            </ol>
+        </nav>
     </div>
-    <div class="guide-main">
-        <div class="grid-row grid-gap">
-            {% assign sidenav = site.data.navigation[page.sidenav] | default: page.sidenav %}
-            {% if sidenav %}
-            <div class="usa-layout-docs__sidenav desktop:grid-col-3{% if page.sticky_sidenav %} usa-sticky-sidenav{% endif %}">
-                {% include sidenav.html links=sidenav %}
-            </div>
-            {% endif %}
-            <div class="usa-layout-docs usa-layout-docs__main usa-prose{% if sidenav %} desktop:grid-col-9{% endif %}">
-                {% if page.title %}
-                <h1>{{ page.title }}</h1>
+</div>
+<div class="guide-main">
+    <div class="">
+        <div class="grid-container">
+            <div class="grid-row grid-gap">
+                {% assign sidenav = site.data.navigation[page.sidenav] | default: page.sidenav %}
+                {% if sidenav %}
+                <div class="usa-layout-docs__sidenav desktop:grid-col-3{% if page.sticky_sidenav %} usa-sticky-sidenav{% endif %}">
+                    {% include sidenav.html links=sidenav %}
+                </div>
                 {% endif %}
-                {{ content }}
+                <div class="usa-layout-docs usa-layout-docs__main usa-prose{% if sidenav %} desktop:grid-col-9{% endif %}">
+                    {% if page.title %}
+                    <h1>{{ page.title }}</h1>
+                    {% endif %}
+                    {{ content }}
+                </div>
             </div>
         </div>
     </div>

--- a/_layouts/playbook.html
+++ b/_layouts/playbook.html
@@ -3,37 +3,38 @@ layout: default
 main:
 class:
 ---
-
-<div class="guide-container">
-    <div class="handbook-breadcrumb">
-        <div class="">
-            <nav class="usa-breadcrumb" aria-label="Breadcrumbs">
-                <ol class="usa-breadcrumb__list">
-                    <li class="usa-breadcrumb__list-item">
-                        <a href="{{ site.baseurl }}/playbook" class="usa-breadcrumb__link">
-                            <span class="guide-title">CivicActions Accessibility Playbook</span>
-                        </a>
-                    </li>
-                    <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
-                        <span>{{ page.title }}</span>
-                    </li>
-                </ol>
-            </nav>
-        </div>
+<div class="main-breadcrumb">
+    <div class="grid-container">
+        <nav class="usa-breadcrumb" aria-label="Breadcrumbs">
+            <ol class="usa-breadcrumb__list">
+                <li class="usa-breadcrumb__list-item">
+                    <a href="{{ site.baseurl }}/playbook" class="usa-breadcrumb__link">
+                        <span class="guide-title">CivicActions Accessibility Playbook</span>
+                    </a>
+                </li>
+                <li class="usa-breadcrumb__list-item usa-current" aria-current="page">
+                    <span>{{ page.title }}</span>
+                </li>
+            </ol>
+        </nav>
     </div>
-    <div class="guide-main">
-        <div class="grid-row grid-gap">
-            {% assign sidenav = site.data.navigation[page.sidenav] | default: page.sidenav %}
-            {% if sidenav %}
-            <div class="usa-layout-docs__sidenav desktop:grid-col-3{% if page.sticky_sidenav %} usa-sticky-sidenav{% endif %}">
-                {% include sidenav-playbook.html links=sidenav %}
-            </div>
-            {% endif %}
-            <div class="usa-layout-docs usa-layout-docs__main usa-prose{% if sidenav %} desktop:grid-col-9{% endif %}">
-                {% if page.title %}
-                <h1>{{ page.title }}</h1>
+</div>
+<div class="guide-main">
+    <div class="">
+        <div class="grid-container">
+            <div class="grid-row grid-gap">
+                {% assign sidenav = site.data.navigation[page.sidenav] | default: page.sidenav %}
+                {% if sidenav %}
+                <div class="usa-layout-docs__sidenav desktop:grid-col-3{% if page.sticky_sidenav %} usa-sticky-sidenav{% endif %}">
+                    {% include sidenav-playbook.html links=sidenav %}
+                </div>
                 {% endif %}
-                {{ content }}
+                <div class="usa-layout-docs usa-layout-docs__main usa-prose{% if sidenav %} desktop:grid-col-9{% endif %}">
+                    {% if page.title %}
+                    <h1>{{ page.title }}</h1>
+                    {% endif %}
+                    {{ content }}
+                </div>
             </div>
         </div>
     </div>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -9,7 +9,7 @@ class:
             <ol class="usa-breadcrumb__list">
                 <li class="usa-breadcrumb__list-item">
                     <a href="{{ site.baseurl }}/projects" class="usa-breadcrumb__link">
-                        <span>CivicActions Accessibility projects</span>
+                        <span class="guide-title">CivicActions Accessibility Projects</span>
                     </a>
                 </li>
                 <li class="usa-breadcrumb__list-item usa-current" aria-current="page">


### PR DESCRIPTION
Currently broken. Screenshot:

![Screen Shot 2021-04-08 at 10 30 35 AM](https://user-images.githubusercontent.com/7096681/114071038-82db8a00-9855-11eb-82e1-fc4d9282bf04.png)

E.g. https://accessibility.civicactions.com/playbook/training

This should fix it and bring it back to be aligned.