### PR TITLE
Search tweaks

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -22,7 +22,7 @@ primary:
     href: /playbook
   - text: Guide
     href: /guide
-  - text: <i class="fas fa-search"><span>Search</span></i>
+  - text: Search
     href: /search
 
 ##  - text: Navigation section

--- a/pages/search.html
+++ b/pages/search.html
@@ -11,7 +11,7 @@ permalink: /search
                 <div id="search-container">
                     <label for="search-input" class="usa-sr-only">Enter Search Term(s):</label>
                     <input type="text" id="search-input">
-                    <ul id="results-container"></ul>
+                    <ul id="results-container" aria-live="polite"></ul>
                 </div>
                 <!-- Script pointing to search-script.js -->
                 <script src="https://unpkg.com/simple-jekyll-search@latest/dest/simple-jekyll-search.min.js"></script>
@@ -20,7 +20,8 @@ permalink: /search
                   SimpleJekyllSearch({
                     searchInput: document.getElementById('search-input'),
                     resultsContainer: document.getElementById('results-container'),
-                    json: '{{ site.url}}/search.json'
+                    json: '{{ site.url}}/search.json',
+                    searchResultTemplate: '<li><a href="{url}">{title}</a></li>'
                   })
                 </script>
             </div>


### PR DESCRIPTION
* Removed search icon from the menu as it is pushing the menu item alignment.
* Added `aria-live="polite"` to search results because it is dynamically loaded. Documentation: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
* Adjusted search result to remove title attribute as it currently says `{desc}` which I think is a bug. See https://github.com/christian-fei/Simple-Jekyll-Search/pull/7