### PR TITLE
QA site action

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,8 @@ Automatically place new/reopened issues in to the project board.
 
 Adding the label 'qa-pull-request' to a pull request will deploy the changes to a [QA site](https://accessibility-qa.civicactions.com/) for review. To reapply the changes remove and readd the label. **Note**: Only one pull request can be viewable on the QA site so use coordinate the deployments.
 
+This pipeline requires a personal access token or organizational one with the key `API_TOKEN_GITHUB`.
+
 # References
 
 * https://github.com/pa11y/pa11y

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,10 @@ Run pre-commit hooks to clean up site based on configurations in .pre-commit-con
 
 Automatically place new/reopened issues in to the project board.
 
+## qa.yml
+
+Adding the label 'qa-pull-request' to a pull request will deploy the changes to a [QA site](https://accessibility-qa.civicactions.com/) for review. To reapply the changes remove and readd the label. **Note**: Only one pull request can be viewable on the QA site so use coordinate the deployments.
+
 # References
 
 * https://github.com/pa11y/pa11y
@@ -37,3 +41,6 @@ Automatically place new/reopened issues in to the project board.
 * https://github.com/marketplace/actions/comment-pull-request
 * https://pre-commit.com/
 * https://github.blog/2021-04-28-use-github-actions-manage-docs/
+* https://stackoverflow.com/questions/62325286/run-github-actions-when-pull-requests-have-a-specific-label
+* https://github.com/marketplace/actions/push-directory-to-another-repository
+* https://github.com/marketplace/actions/find-and-replace

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,47 @@
+name: QA pull request
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  build:
+    name: Building QA site to review pull request
+    if: contains(github.event.pull_request.labels.*.name, 'qa-pull-request')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source.
+        uses: actions/checkout@v2
+
+      - name: Find and replace the main site domain
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          find: "accessibility.civicactions.com"
+          replace: "accessibility-qa.civicactions.com"
+
+      - name: Install jekyll site dependencies.
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+
+      - name: Build jekyll site.
+        run: bundle exec jekyll build
+
+      - name: Push _site directory to QA repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: '_site'
+          destination-github-username: 'CivicActions'
+          destination-repository-name: 'accessibility-qa'
+          commit-message: See ORIGIN_COMMIT from $GITHUB_REF
+          target-branch: main
+
+      - name: Comment on pull request.
+        uses: thollander/actions-comment-pull-request@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: "You can test changes in this branch at [https://accessibility-qa.civicactions.com/](https://accessibility-qa.civicactions.com/). If you pushed additional changes and need to reapply them, remove and readd the label 'qa-pull-request'."

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -28,6 +28,15 @@ jobs:
 
       - name: Build jekyll site.
         run: bundle exec jekyll build
+        
+      - name: Replace contents of robots.txt
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          find: "Sitemap: https://accessibility-qa.civicactions.com/sitemap.xml"
+          replace: |
+            User-agent: *
+            Disallow: /
+          include: "robots.txt"
 
       - name: Push _site directory to QA repository
         uses: cpina/github-action-push-to-another-repository@main


### PR DESCRIPTION
Adding an action that will update the QA site with the changes in the pull request.

How it works:
* Make changes and submit a pull request.
* Add the label 'qa-pull-request' to the pull request.
* Wait for the action to complete and a few minutes to have passed.
* Then navigate to https://accessibility-qa.civicactions.com/ to review the changes.

The QA site repo is available here: https://github.com/CivicActions/accessibility-qa to review whether the GitHub pages has run successfully.

Closes: #408 