### PR TITLE
Update retext.suggestion.js

### DIFF
--- a/lint/config/retext.suggestion.js
+++ b/lint/config/retext.suggestion.js
@@ -7,8 +7,6 @@ var remark2retext = require("remark-retext");
 var english = require("retext-english");
 var contractions = require("retext-contractions");
 var readability = require("retext-readability");
-var spell = require("retext-spell");
-var dictionary = require('dictionary-en')
 var equality = require("retext-equality");
 
 var ignoreWords = [
@@ -31,9 +29,5 @@ function attacher() {
         threshold: 5 / 7,
       })
       .use(equality, { ignore: ignoreWords || [] })
-      .use(spell, {
-        dictionary: dictionary,
-        ignore: ignoreWords || []
-      })
   );
 }


### PR DESCRIPTION
Removing spell checker. Too many false positives to keep up.

@mgifford you are on your own ;). Maybe we can get GitHub to add spell check to the editor. I think because it is code editor they don't want that.