### PR TITLE
Changed card background and implemented reduced motion option

### DIFF
--- a/_sass/uswds/components/_card.scss
+++ b/_sass/uswds/components/_card.scss
@@ -21,19 +21,19 @@
   a,
   .usa-card__heading{
     text-decoration: none;
-    color: black;
+    color: #1b1b1b;
   }
   .usa-card__container {
-    border: 2px solid black;
+    border: 2px solid #1b1b1b;
     color: white;
     text-decoration: underline;
     .usa-card__img {
-      background-color: black;
+      background-color: #1b1b1b;
     }
     &:hover,
     &:focus,
     &:focus-within {
-      background-color: black;
+      background-color: #1b1b1b;
       a,
       .usa-card__heading {
         color: white;
@@ -42,7 +42,15 @@
       .usa-card__img {
         background-color: white;
         i::before {
-          color: black;
+          color: #1b1b1b;
+        }
+      }
+      @media (prefers-reduced-motion) {
+        .usa-card__img {
+          background-color: initial;
+          i::before {
+            color: white;
+          }
         }
       }
     }


### PR DESCRIPTION
The background will now match the banners. The reduced motion option should allow folks who check that to not see the hover effect on the images/icons in the cards.

To toggle the 'reduce motion' setting follow the steps:

- On a Mac, you go to "System Preferences -> Accessibility -> Display" and check the box for "Reduce motion".
- On iOS go to "Settings -> General -> Accessibility" and turn on"Reduce Motion".
- On Win10 go to "Settings -> Ease of Access -> Display -> Simplify and personalise Windows". Set "Show animation in Windows" to off.

References:
* https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
* https://a11y-101.com/development/reduced-motion
* https://accessibility.civicactions.com/playbook/personalization#checklist

Fixes #429 