### PR TITLE
Updated packages including pa11y-ci.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2769,9 +2769,9 @@
       }
     },
     "node_modules/pa11y-ci": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-2.4.1.tgz",
-      "integrity": "sha512-H+JBQBTcpj1jkNHp/A9JTppQPx8DpYgM9Er9Sb7ebRCCKlUIqgo9/Vmt/3sUkkvoDqU5mjkRTQSNj1PnoIrS/Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-2.4.2.tgz",
+      "integrity": "sha512-Gv8vLm9t394jfErQNPOjbrqWGWM1/VdjiMPmLTS7K5tHKrm4pZgBhMdLOhEPPmfFkbcCZac37qjSr6lfln66Bg==",
       "dev": true,
       "dependencies": {
         "async": "~2.6.3",
@@ -5769,9 +5769,9 @@
       }
     },
     "pa11y-ci": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-2.4.1.tgz",
-      "integrity": "sha512-H+JBQBTcpj1jkNHp/A9JTppQPx8DpYgM9Er9Sb7ebRCCKlUIqgo9/Vmt/3sUkkvoDqU5mjkRTQSNj1PnoIrS/Q==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/pa11y-ci/-/pa11y-ci-2.4.2.tgz",
+      "integrity": "sha512-Gv8vLm9t394jfErQNPOjbrqWGWM1/VdjiMPmLTS7K5tHKrm4pZgBhMdLOhEPPmfFkbcCZac37qjSr6lfln66Bg==",
       "dev": true,
       "requires": {
         "async": "~2.6.3",


### PR DESCRIPTION
A [new version of pa11y-ci ](https://github.com/pa11y/pa11y-ci/releases/tag/2.4.2) came out. This might help with the pa11y pipeline errors.