### PR TITLE
Changing champions program icon.

### DIFF
--- a/_data/guide.yml
+++ b/_data/guide.yml
@@ -79,4 +79,4 @@ docs:
 - title: Champions program
   url: /champions-program
   description: 
-  icon: <i class="fas fa-people-group fa-5x" aria-hidden="true"></i>
+  icon: <i class="fas fa-group fa-5x" aria-hidden="true"></i>


### PR DESCRIPTION
Unfortunately `fa-people-group` doesn't render but `fa-group` does.