### PR TITLE
Adding htmlcs runner as well for pa11yci

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -2,7 +2,7 @@
   "defaults": {
     "concurrency": 1,
     "standard": "WCAG2AA",
-    "runners": ["axe"],
+    "runners": ["axe", "htmlcs"],
     "ignore": [
       "color-contrast",
       "frame-tested"


### PR DESCRIPTION
Adding `htmlcs` as an additional runner to see if we do get errors.