### PR TITLE
Ignoring dependabot PRs in cypress and pa11y workflows

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Publish test results.
         uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
+        if: github.actor != 'dependabot[bot]'
         with:
           files: cypress/results/*.xml
           check_name: "Cypress Test Results"

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Comment on pull request.
         uses: thollander/actions-comment-pull-request@v1
+        if: github.actor != 'dependabot[bot]'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: '<details><summary>Pa11y testing results</summary>


### PR DESCRIPTION
When dependabot fixes something we can ignore the comment on the PR from cypress and pa11y. Solution from https://github.com/CivicActions/cypress-tests/pull/28