### PR TITLE
ci(action): fix localhost network target

### DIFF
--- a/.github/workflows/a11ywatch.yml
+++ b/.github/workflows/a11ywatch.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: a11ywatch/github-action@v1.14.0
         with:
-          WEBSITE_URL: http://localhost:4000
+          WEBSITE_URL: http://host.docker.internal:4000
           SITE_WIDE: true
           SITEMAP: true
           LIST: true


### PR DESCRIPTION
Temporarily target local network for testing until the github action uses bare metal installs without docker.