### PR TITLE
Adding accessibility-alt-text-bot

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,6 +38,10 @@ Run Cypress tests with Axe to check accessibility of the site with axe by intera
 
 Run a11ywatch GitHub action to check accessibility of the site.
 
+## accessibility-alt-text-bot.yml
+
+This action reminds users to add a meaningful alternative text to their images.
+
 # References
 
 * https://github.com/pa11y/pa11y

--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -1,0 +1,26 @@
+name: Accessibility-alt-text-bot
+on: 
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
+  
+jobs:
+  accessibility_alt_text_bot:
+    name: Check alt text is set on issue or pull requests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue || github.event.pull_request || github.event.discussion }}
+    steps:
+      - name: Get action 'github/accessibility-alt-text-bot'
+        uses: github/accessibility-alt-text-bot@v1.3.0


### PR DESCRIPTION
Taken from https://github.blog/2023-06-12-make-your-github-projects-more-accessible-with-accessibility-alt-text-bot/.

Example of image without alt text:

![](https://github.com/CivicActions/accessibility/assets/7096681/d528848c-1366-4215-a830-75891fb2820b)
