### PR TITLE
Update formatting and AuDS link on design.md

### DIFF
--- a/_guide/design.md
+++ b/_guide/design.md
@@ -22,9 +22,9 @@ Worldwide, government website design is being led by open source initiatives.
 
 ### Europe and the UK
 *   [GOV.UK – Design System](https://design-system.service.gov.uk/) — [GOV.UK Design System on GitHub](https://github.com/alphagov/govuk-design-system)
-*   [UK’s Department for Work and Pensions Design System on GitHub](https://github.com/dwp/design-system)
-*   [Iceland’s design system mono repository](https://github.com/island-is/island.is)
-*   [Portugal’s Ágora Design System](https://zeroheight.com/1be481dc2/p/2861fa-boas-vindas)
+*   [UK's Department for Work and Pensions Design System on GitHub](https://github.com/dwp/design-system)
+*   [Iceland's design system mono repository](https://github.com/island-is/island.is)
+*   [Portugal's Ágora Design System](https://zeroheight.com/1be481dc2/p/2861fa-boas-vindas)
 
 ### Canada
 *   [Canada – Web Experience Toolkit (WET)](https://wet-boew.github.io/wet-boew/index.html) — [WET on GitHub](https://github.com/wet-boew/wet-boew)
@@ -33,35 +33,35 @@ Worldwide, government website design is being led by open source initiatives.
 
 ### Australia, NZ and Pacific
 *   [Australia – Design System](https://web.archive.org/web/20210907155703/https://designsystem.gov.au/) (Archive.org) — [Design System Components on GitHub](https://github.com/govau/design-system-components/)
-*   [Australia’s Health Design System](https://designsystem.health.gov.au/) — [Health on GitHub](https://github.com/healthgovau/health-design-system)
+*   [Australia's Health Design System](https://designsystem.health.gov.au/) — [Health on GitHub](https://github.com/healthgovau/health-design-system)
 *   [NZ – Design System](https://design-system-alpha.digital.govt.nz/) — [govtnz-design-system on GitHub](https://github.com/GOVTNZ/govtnz-design-system)
 *   [Singapore Government Design System](https://www.designsystem.tech.gov.sg) — [SGDS on GitHub](https://github.com/govtechsg/sgds)
 
 ### Municipal
 *   [City of Helsinki Design System](https://github.com/City-of-Helsinki/helsinki-design-system)
-*   [The New York Public Library’s Design System](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/welcome--page) — [NYPL on GitHub](https://github.com/NYPL/nypl-design-system)
+*   [The New York Public Library's Design System](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/welcome--page) — [NYPL on GitHub](https://github.com/NYPL/nypl-design-system)
 
 
 ## Other open design systems {#other-open-design-systems}
 
-*   [Okta’s Odyssey Design System](https://github.com/okta/odyssey)
-*   [IBM’s Carbon open source design system](https://www.carbondesignsystem.com/) — [Carbon on GitHub](https://github.com/carbon-design-system/carbon) [Carbon’s Accessibility](https://www.carbondesignsystem.com/guidelines/accessibility/overview/) (uses Web Components)
+*   [Okta's Odyssey Design System](https://github.com/okta/odyssey)
+*   [IBM's Carbon open source design system](https://www.carbondesignsystem.com/) — [Carbon on GitHub](https://github.com/carbon-design-system/carbon) [Carbon's Accessibility](https://www.carbondesignsystem.com/guidelines/accessibility/overview/) (uses Web Components)
 *   [Impact Design System](https://demos.creative-tim.com/impact-design-system/index.html) — [Impact Desigh System on GitHub](https://github.com/creativetimofficial/impact-design-system)
-*   [VMWare’s Clarity Design System](https://clarity.design/) — [Clarity on GitHub](https://github.com/vmware/clarity) [Clarity’s Accessibility](https://clarity.design/get-started/support/) (uses Web Components)
-*   [Emulsify](https://www.emulsify.info/) — [Emulsify on GitHub](https://github.com/emulsify-ds) [Emulsify’s Accessibility](https://docs.emulsify.info/usage/accessibility-testing)
-*   [ING’s Lion Design System](https://lion-web-components.netlify.app/?path=/story/*) — [Lion on GitHub](https://github.com/ing-bank/lion) [Lion’s Accessibility](https://lion-web.netlify.app/blog/ing-open-sources-lion/#accessibility) (uses Web Components)
-*   [Talend’s Coral Design System](https://design.talend.com/) — [Coral on GitHub](https://github.com/Talend/ui/) (uses React Components)
+*   [VMWare's Clarity Design System](https://clarity.design/) — [Clarity on GitHub](https://github.com/vmware/clarity) [Clarity's Accessibility](https://clarity.design/get-started/support/) (uses Web Components)
+*   [Emulsify](https://www.emulsify.info/) — [Emulsify on GitHub](https://github.com/emulsify-ds) [Emulsify's Accessibility](https://docs.emulsify.info/usage/accessibility-testing)
+*   [ING's Lion Design System](https://lion-web-components.netlify.app/?path=/story/*) — [Lion on GitHub](https://github.com/ing-bank/lion) [Lion's Accessibility](https://lion-web.netlify.app/blog/ing-open-sources-lion/#accessibility) (uses Web Components)
+*   [Talend's Coral Design System](https://design.talend.com/) — [Coral on GitHub](https://github.com/Talend/ui/) (uses React Components)
 *   [Orange Digital Accessibility](https://a11y-guidelines.orange.com/en/) — [Orange a11y-guidelines on GitHub](https://github.com/Orange-OpenSource/a11y-guidelines)
-*   [Google’s Material Design](https://material.io/) — [Material on GitHub](https://github.com/material-components) [Material’s Accessibility](https://material.io/design/usability/accessibility.html) (uses Web Components)
-*   [Adobe’s Spectrum](https://spectrum.adobe.com/) — [Spectrum’s Inclusive Design](https://spectrum.adobe.com/page/inclusive-design/) (uses Web Components)
-*   [Microsoft’s Fluent](https://www.microsoft.com/design/fluent/) [Fluent UI on GitHub](https://github.com/microsoft/fluentui)
-*   [Bridge Lab’s Bold](https://bold.bridge.ufsc.br/en/) — [Bold on GitHub](https://github.com/laboratoriobridge/bold) [Bold’s Accessibility](https://bold.bridge.ufsc.br/en/design-guidelines/accessibility/)
-*   [Shopify’s Polaris](https://polaris.shopify.com/) — [Polaris on GitHub](https://github.com/topics/shopify-polaris) [Polaris' Accessibility](https://polaris.shopify.com/foundations/accessibility)
-*   [Intuit’s Design-systems-cli](https://intuit.github.io/design-systems-cli/) — [Intuit on GitHub](https://github.com/intuit/design-systems-cli) [Quickbooks' Accessibility](https://designsystem.quickbooks.com/bolt/accessibility/)
-*   [Spark Design System](https://sparkdesignsystem.com/) — [Spark on GitHub](https://github.com/sparkdesignsystem/spark-design-system) [Spark’s Accessibility](https://sparkdesignsystem.com/principles/accessibility-guidelines/#accessibility-guidelines)
-*   [Redhat’s Patternfly](https://www.patternfly.org/) — [Patternfly on GitHub](https://github.com/patternfly/patternfly)
-*   [SAP’s UI5](https://sap.github.io/ui5-webcomponents/) — [UI5 on GitHub](https://github.com/SAP/ui5-webcomponents) (uses Web Components)
-*   [Phase2’s Outline](https://outline.phase2tech.com/) — [Outline on GitHub](https://github.com/phase2/outline) (uses Web Components)
-*   [Washington Post’s Design System (UiKit)](https://build.washingtonpost.com)
-*   [GitHub’s Primer](https://primer.style/) — [Primer on GitHub](https://github.com/primer)
-*   [Jstor’s Pharos](https://pharos.jstor.org/) — [Pharos on GitHub](https://github.com/ithaka/pharos)
+*   [Google's Material Design](https://material.io/) — [Material on GitHub](https://github.com/material-components) [Material's Accessibility](https://material.io/design/usability/accessibility.html) (uses Web Components)
+*   [Adobe's Spectrum](https://spectrum.adobe.com/) — [Spectrum's Inclusive Design](https://spectrum.adobe.com/page/inclusive-design/) (uses Web Components)
+*   [Microsoft's Fluent](https://www.microsoft.com/design/fluent/) [Fluent UI on GitHub](https://github.com/microsoft/fluentui)
+*   [Bridge Lab's Bold](https://bold.bridge.ufsc.br/en/) — [Bold on GitHub](https://github.com/laboratoriobridge/bold) [Bold's Accessibility](https://bold.bridge.ufsc.br/en/design-guidelines/accessibility/)
+*   [Shopify's Polaris](https://polaris.shopify.com/) — [Polaris on GitHub](https://github.com/topics/shopify-polaris) [Polaris' Accessibility](https://polaris.shopify.com/foundations/accessibility)
+*   [Intuit's Design-systems-cli](https://intuit.github.io/design-systems-cli/) — [Intuit on GitHub](https://github.com/intuit/design-systems-cli) [Quickbooks' Accessibility](https://designsystem.quickbooks.com/bolt/accessibility/)
+*   [Spark Design System](https://sparkdesignsystem.com/) — [Spark on GitHub](https://github.com/sparkdesignsystem/spark-design-system) [Spark's Accessibility](https://sparkdesignsystem.com/principles/accessibility-guidelines/#accessibility-guidelines)
+*   [Redhat's Patternfly](https://www.patternfly.org/) — [Patternfly on GitHub](https://github.com/patternfly/patternfly)
+*   [SAP's UI5](https://sap.github.io/ui5-webcomponents/) — [UI5 on GitHub](https://github.com/SAP/ui5-webcomponents) (uses Web Components)
+*   [Phase2's Outline](https://outline.phase2tech.com/) — [Outline on GitHub](https://github.com/phase2/outline) (uses Web Components)
+*   [Washington Post's Design System (UiKit)](https://build.washingtonpost.com)
+*   [GitHub's Primer](https://primer.style/) — [Primer on GitHub](https://github.com/primer)
+*   [Jstor's Pharos](https://pharos.jstor.org/) — [Pharos on GitHub](https://github.com/ithaka/pharos)


### PR DESCRIPTION
Using this as practice. Updated some formatting characters to improve readability (swapped hyphen - for em dash —, prime ' for right apostrophe ’, etc.). Also updated the Australian Government Design System link to point to the Archive.org version because they discontinued it in 2021.