### PR TITLE
Removing VA link since it is not working

### DIFF
--- a/_guide/documents.md
+++ b/_guide/documents.md
@@ -15,6 +15,7 @@ For Microsoft Word/Powerpoint, portable document formats and electronic publicat
 
 ## Government recommendations
 *   [Section508.gov: Create Accessible Documents](https://www.section508.gov/create/documents) (U.S. General Services Administration)
+*   [DigitalVA: Accessibility Guide](https://digital.va.gov/accessibility/)
 *   [Why GOV.UK content should be published in HTML and not PDF](https://gds.blog.gov.uk/2018/07/16/why-gov-uk-content-should-be-published-in-html-and-not-pdf/) (UK Government Digital Service)
 *   [Gov.uk: Publishing accessible documents](https://www.gov.uk/guidance/publishing-accessible-documents) (UK Government Digital Service)
 *   [Canada.ca: Digital Accessibility Toolkit](https://a11y.canada.ca/en/)


### PR DESCRIPTION
# One-line summary

@mgifford from https://github.com/CivicActions/accessibility/actions/runs/17036037475/job/48288644521 the link is redirecting to a non-working page. It might start working again but for now creating a PR to remove the link.

The link in question https://www.oit.va.gov/accessibility/
