### PR TITLE
Removing broken link from onboarding-staff.md

### DIFF
--- a/_guide/design.md
+++ b/_guide/design.md
@@ -60,7 +60,7 @@ Worldwide, government website design is being led by open source initiatives.
 *   [Intuit's Design-systems-cli](https://intuit.github.io/design-systems-cli/) — [Intuit on GitHub](https://github.com/intuit/design-systems-cli) [Quickbooks' Accessibility](https://designsystem.quickbooks.com/bolt/accessibility/)
 *   [Spark Design System](https://sparkdesignsystem.com/) — [Spark on GitHub](https://github.com/sparkdesignsystem/spark-design-system) [Spark's Accessibility](https://sparkdesignsystem.com/principles/accessibility-guidelines/#accessibility-guidelines)
 *   [Redhat's Patternfly](https://www.patternfly.org/) — [Patternfly on GitHub](https://github.com/patternfly/patternfly)
-*   [SAP's UI5](https://sap.github.io/ui5-webcomponents/) — [UI5 on GitHub](https://github.com/SAP/ui5-webcomponents) (uses Web Components)
+*   [SAP's UI5](http://ui5.github.io/webcomponents/) — [UI5 on GitHub](https://github.com/UI5/webcomponents) (uses Web Components)
 *   [Phase2's Outline](https://outline.phase2tech.com/) — [Outline on GitHub](https://github.com/phase2/outline) (uses Web Components)
 *   [Washington Post's Design System (UiKit)](https://build.washingtonpost.com)
 *   [GitHub's Primer](https://primer.style/) — [Primer on GitHub](https://github.com/primer)

--- a/_guide/design.md
+++ b/_guide/design.md
@@ -60,7 +60,7 @@ Worldwide, government website design is being led by open source initiatives.
 *   [Intuit's Design-systems-cli](https://intuit.github.io/design-systems-cli/) — [Intuit on GitHub](https://github.com/intuit/design-systems-cli) [Quickbooks' Accessibility](https://designsystem.quickbooks.com/bolt/accessibility/)
 *   [Spark Design System](https://sparkdesignsystem.com/) — [Spark on GitHub](https://github.com/sparkdesignsystem/spark-design-system) [Spark's Accessibility](https://sparkdesignsystem.com/principles/accessibility-guidelines/#accessibility-guidelines)
 *   [Redhat's Patternfly](https://www.patternfly.org/) — [Patternfly on GitHub](https://github.com/patternfly/patternfly)
-*   [SAP's UI5](http://ui5.github.io/webcomponents/) — [UI5 on GitHub](https://github.com/UI5/webcomponents) (uses Web Components)
+*   [SAP's UI5](https://ui5.github.io/webcomponents/) — [UI5 on GitHub](https://github.com/UI5/webcomponents) (uses Web Components)
 *   [Phase2's Outline](https://outline.phase2tech.com/) — [Outline on GitHub](https://github.com/phase2/outline) (uses Web Components)
 *   [Washington Post's Design System (UiKit)](https://build.washingtonpost.com)
 *   [GitHub's Primer](https://primer.style/) — [Primer on GitHub](https://github.com/primer)

--- a/_guide/onboarding-staff.md
+++ b/_guide/onboarding-staff.md
@@ -102,6 +102,7 @@ Accessibility onboarding is key to ensuring that all team members have a basic u
 ## Resources
 
 * [Microsoft's Accessibility Fundamentals Workshop](https://docs.microsoft.com/en-us/learn/paths/accessibility-fundamentals/)
+* [Disability:In's Disability Fundamentals Training for Managers](https://web.archive.org/web/20250806094735/https://disabilityin.org/resource/disability-fundamentals-training-for-managers/)
 
 ## Next Steps
 

--- a/_guide/onboarding-staff.md
+++ b/_guide/onboarding-staff.md
@@ -102,7 +102,6 @@ Accessibility onboarding is key to ensuring that all team members have a basic u
 ## Resources
 
 * [Microsoft's Accessibility Fundamentals Workshop](https://docs.microsoft.com/en-us/learn/paths/accessibility-fundamentals/)
-* [Disability:In's Disability Fundamentals Training for Managers](https://disabilityin.org/resource/disability-fundamentals-training-for-managers/)
 
 ## Next Steps
 


### PR DESCRIPTION
https://disabilityin.org/resource/disability-fundamentals-training-for-managers/ goes to a 404 page.

Also updating links on `design.md`. New links https://github.com/UI5/webcomponents and https://ui5.github.io/webcomponents/.

@mgifford do you have an alternative link?
