### PR TITLE
Removing broken links

### DIFF
--- a/_guide/social-media.md
+++ b/_guide/social-media.md
@@ -35,7 +35,6 @@ Social media is used to create and share ideas, information, and interests. Acce
 ## Resources
 
 * [Accessible Social's free resource and education hub for social media](https://www.accessible-social.com/)
-* [Digital.gov's toolkit for improving the accessibility of social media in government](https://digital.gov/resources/improving-the-accessibility-of-social-media-in-government/)
 * [Planning, creating and publishing accessible social media campaigns](https://gcs.civilservice.gov.uk/guidance/digital-communication/planning-creating-and-publishing-accessible-social-media-campaigns/)
 * [How to make images accessible for people on X (formerly Twitter)](https://help.x.com/en/using-x/picture-descriptions)
 

--- a/_people/jonathan-bourland.md
+++ b/_people/jonathan-bourland.md
@@ -9,11 +9,11 @@ categories:
  - 
 sidenav: docs
 
-linkedin: https://www.linkedin.com/in/jonathan-bourland-6896334/
+linkedin:
 twitter:
 github: https://github.com/jonbot
 gitlab:
-drupal:
+drupal: https://www.drupal.org/u/majorrobot
 speakerdeck:
 website:
 external: false

--- a/_people/mike-gifford.md
+++ b/_people/mike-gifford.md
@@ -8,7 +8,7 @@ categories:
  - Accessibility
 sidenav: docs
 permalink: /about/people/mike-gifford
-linkedin: https://www.linkedin.com/in/mgifford/
+linkedin:
 twitter: https://twitter.com/mgifford
 github: https://github.com/mgifford
 gitlab: 

--- a/_posts/2021-3-12-government-accessibility-and-the-cms-problem.md
+++ b/_posts/2021-3-12-government-accessibility-and-the-cms-problem.md
@@ -67,7 +67,6 @@ widespread.
 
  **Connect with Mike**
 
-  * [LinkedIn](https://www.linkedin.com/in/mgifford/?originalSubdomain=ca)
   * [GitHub](https://github.com/mgifford)
   * [Drupal](https://www.drupal.org/u/mgifford)
   * [Medium](https://medium.com/@mgifford)

--- a/_posts/2021-5-6-qa-with-mike-gifford-accessibility-in-civic-tech.md
+++ b/_posts/2021-5-6-qa-with-mike-gifford-accessibility-in-civic-tech.md
@@ -185,7 +185,6 @@ too.
 
 ####  **Connect with Mike**
 
-  * [LinkedIn](https://www.linkedin.com/in/mgifford/)
   * [GitHub](https://github.com/mgifford)
   * [Medium](https://mgifford.medium.com/)
   * [Twitter](https://twitter.com/mgifford)

--- a/_posts/2024-1-31-delivering-digital-first-turning-21st-century-idea-into-action.md
+++ b/_posts/2024-1-31-delivering-digital-first-turning-21st-century-idea-into-action.md
@@ -4,8 +4,7 @@ title: "Delivering Digital First: Turning 21st Century IDEA into Action"
 date: 2024-1-31 08:00:00 -0800
 author: civicactions
 ---
-By [Mike Gifford](https://www.linkedin.com/in/mgifford/) and Emily
-Ryan
+By Mike Gifford and Emily Ryan
 
 ![Capitol building with American flag](https://cdn-images-1.medium.com/max/1024/1*Gjq0z86HnUQR33ezNnxFog.jpeg)
 


### PR DESCRIPTION
Removing links to Linkedin and digital.gov that is now a 404. The links are being flagged in https://github.com/CivicActions/accessibility/actions/runs/25663801211/job/75330951251
