### PR TITLE
Removing broken, ignoring linkedin URLs and added Drupal.org link

### DIFF
--- a/_guide/social-media.md
+++ b/_guide/social-media.md
@@ -35,7 +35,6 @@ Social media is used to create and share ideas, information, and interests. Acce
 ## Resources
 
 * [Accessible Social's free resource and education hub for social media](https://www.accessible-social.com/)
-* [Digital.gov's toolkit for improving the accessibility of social media in government](https://digital.gov/resources/improving-the-accessibility-of-social-media-in-government/)
 * [Planning, creating and publishing accessible social media campaigns](https://gcs.civilservice.gov.uk/guidance/digital-communication/planning-creating-and-publishing-accessible-social-media-campaigns/)
 * [How to make images accessible for people on X (formerly Twitter)](https://help.x.com/en/using-x/picture-descriptions)
 

--- a/_people/jonathan-bourland.md
+++ b/_people/jonathan-bourland.md
@@ -13,7 +13,7 @@ linkedin: https://www.linkedin.com/in/jonathan-bourland-6896334/
 twitter:
 github: https://github.com/jonbot
 gitlab:
-drupal:
+drupal: https://www.drupal.org/u/majorrobot
 speakerdeck:
 website:
 external: false

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pa11y-ci:home": "pa11y-ci http://127.0.0.1:4000",
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml --sitemap-find https://accessibility.civicactions.com --sitemap-replace http://127.0.0.1:4000 --sitemap-exclude \"/*.pdf\"",
     "cypress-tests": "cypress run --browser chrome --headless",
-    "link-checker": "bundle exec htmlproofer --ignore-status-codes \"999,429,403,401,307,302,0\" --ignore-urls \"/fonts.gstatic.com/\" --ignore_files \"./_site/ACR/Drupal9AccessibilityConformanceReport-December2020.html,./_site/ACR/Drupal9AccessibilityConformanceReport.html\" ./_site"
+    "link-checker": "bundle exec htmlproofer --ignore-status-codes \"999,429,403,401,307,302,0\" --ignore-urls \"/fonts.gstatic.com/\" --ignore-urls \"/www.linkedin.com/\" --ignore_files \"./_site/ACR/Drupal9AccessibilityConformanceReport-December2020.html,./_site/ACR/Drupal9AccessibilityConformanceReport.html\" ./_site"
   },
   "dependencies": {
     "simple-jekyll-search": "^1.9.2"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pa11y-ci:home": "pa11y-ci http://127.0.0.1:4000",
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml --sitemap-find https://accessibility.civicactions.com --sitemap-replace http://127.0.0.1:4000 --sitemap-exclude \"/*.pdf\"",
     "cypress-tests": "cypress run --browser chrome --headless",
-    "link-checker": "bundle exec htmlproofer --ignore-status-codes \"999,429,403,401,307,302,0\" --ignore-urls \"/fonts.gstatic.com/\" --ignore-urls \"/www.linkedin.com/\" --ignore_files \"./_site/ACR/Drupal9AccessibilityConformanceReport-December2020.html,./_site/ACR/Drupal9AccessibilityConformanceReport.html\" ./_site"
+    "link-checker": "bundle exec htmlproofer --ignore-status-codes \"999,429,403,401,307,302,0\" --ignore-urls \"/fonts.gstatic.com/,/www.linkedin.com/\" --ignore_files \"./_site/ACR/Drupal9AccessibilityConformanceReport-December2020.html,./_site/ACR/Drupal9AccessibilityConformanceReport.html\" ./_site"
   },
   "dependencies": {
     "simple-jekyll-search": "^1.9.2"


### PR DESCRIPTION
Removing checks for Linkedin links because they have been failing checks, e.g. https://github.com/CivicActions/accessibility/actions/runs/25663801211/job/75330951251

Removed digital.gov link that is now a 404 and added Drupal.org link for Jonathan

Replaces #886 